### PR TITLE
Update runtime to 6.10

### DIFF
--- a/com.cyberbotics.webots.yaml
+++ b/com.cyberbotics.webots.yaml
@@ -1,6 +1,6 @@
 app-id: com.cyberbotics.webots
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: webots
 sdk-extensions:
@@ -13,12 +13,6 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --device=dri
-
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: '24.08'
-    add-ld-path: .
 
 cleanup:
   - /bin/*swig


### PR DESCRIPTION
Also, drop the ffmpeg extension 

Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10, and 5.15-25.08) provides FFMPEG; therefore, declaring org.freedesktop.Platform.ffmpeg-full extension is no longer required.

Fixes https://github.com/flathub/com.cyberbotics.webots/issues/3